### PR TITLE
Update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/shiftstack/os-proxy
 
 go 1.21.1
 
-require github.com/gofrs/uuid v4.3.1+incompatible
+require github.com/gofrs/uuid/v5 v5.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/shiftstack/os-proxy
 
-go 1.19
+go 1.21.1
 
 require github.com/gofrs/uuid v4.3.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
-github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid/v5 v5.0.0 h1:p544++a97kEL+svbcFbCQVM9KFu0Yo25UoISXGNNH9M=
+github.com/gofrs/uuid/v5 v5.0.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=

--- a/proxy/dumpers.go
+++ b/proxy/dumpers.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build ignore
+//go:build ignore
 
 package proxy
 

--- a/proxy/targets.go
+++ b/proxy/targets.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gofrs/uuid"
+	"github.com/gofrs/uuid/v5"
 )
 
 type Target struct {


### PR DESCRIPTION
* Use Go v1.21.1
* Use [gofrs/uuid v5](https://github.com/gofrs/uuid/releases/tag/v5.0.0)